### PR TITLE
fix: Support for Cleura Compliant cloud

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,7 @@ linters:
   enable:
     - durationcheck
     - errcheck
-    - exportloopref
+    - copyloopvar 
     - forcetypeassert
     - godot
     - gofmt
@@ -20,7 +20,7 @@ linters:
     - nilerr
     - predeclared
     - staticcheck
-    - tenv
+    - usetesting
     - unconvert
     - unparam
     - unused

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: "v1.57.2"
+    rev: "v1.64.8"
     hooks:
       - id: golangci-lint-full

--- a/cmd/cleura/common/common.go
+++ b/cmd/cleura/common/common.go
@@ -44,6 +44,13 @@ func CleuraAuthFlags() []cli.Flag {
 func LocationFlags() []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
+			Name:        "gardener-domain",
+			Category:    "Location settings",
+			Usage:       "Specify gardener domain, defaults to 'public'",
+			EnvVars:     []string{"CLEURA_API_GARDENER_DOMAIN"},
+			DefaultText: "public",
+		},
+		&cli.StringFlag{
 			Name:     "region",
 			Category: "Location settings",
 			Aliases:  []string{"r"},

--- a/cmd/cleura/shootcmd/createcmd.go
+++ b/cmd/cleura/shootcmd/createcmd.go
@@ -130,6 +130,7 @@ func createCommand() *cli.Command {
 				"api-host",
 				"region",
 				"project-id",
+				"gardener-domain",
 			)
 			if err != nil {
 				return err
@@ -146,7 +147,7 @@ func createCommand() *cli.Command {
 			}
 			if ctx.Bool("cluster") {
 				clusterReq := generateShootClusterRequest(ctx)
-				_, err := client.CreateShootCluster(ctx.String("region"), ctx.String("project-id"), clusterReq)
+				_, err := client.CreateShootCluster(ctx.String("gardener-domain"), ctx.String("region"), ctx.String("project-id"), clusterReq)
 				if err != nil {
 					re, ok := err.(*cleura.RequestAPIError)
 					if ok {
@@ -166,7 +167,7 @@ func createCommand() *cli.Command {
 				// 	return err
 				// }
 				// fmt.Printf("%s", string(body))
-				resp, err := client.AddWorkerGroup(ctx.String("cluster-name"), ctx.String("region"), ctx.String("project-id"), wgReq)
+				resp, err := client.AddWorkerGroup(ctx.String("gardener-domain"), ctx.String("cluster-name"), ctx.String("region"), ctx.String("project-id"), wgReq)
 				if err != nil {
 					re, ok := err.(*cleura.RequestAPIError)
 					if ok {

--- a/cmd/cleura/shootcmd/deletecmd.go
+++ b/cmd/cleura/shootcmd/deletecmd.go
@@ -66,6 +66,7 @@ func deleteCommand() *cli.Command {
 				"api-host",
 				"region",
 				"project-id",
+				"gardener-domain",
 			)
 			if err != nil {
 				return err

--- a/cmd/cleura/shootcmd/deletecmd.go
+++ b/cmd/cleura/shootcmd/deletecmd.go
@@ -81,7 +81,7 @@ func deleteCommand() *cli.Command {
 				return err
 			}
 			if ctx.Bool("cluster") {
-				_, err := client.DeleteShootCluster(ctx.String("cluster-name"), ctx.String("region"), ctx.String("project-id"))
+				_, err := client.DeleteShootCluster(ctx.String("gardener-domain"), ctx.String("cluster-name"), ctx.String("region"), ctx.String("project-id"))
 				if err != nil {
 					re, ok := err.(*cleura.RequestAPIError)
 					if ok {
@@ -94,7 +94,7 @@ func deleteCommand() *cli.Command {
 				fmt.Printf("Cluster: `%s` is being deleted.\nPlease check operation status with `cleura shoot list` command\n", ctx.String("cluster-name"))
 			}
 			if ctx.Bool("workergroup") {
-				_, err := client.DeleteWorkerGroup(ctx.String("cluster-name"), ctx.String("region"), ctx.String("project-id"), ctx.String("wg-name"))
+				_, err := client.DeleteWorkerGroup(ctx.String("gardener-domain"), ctx.String("cluster-name"), ctx.String("region"), ctx.String("project-id"), ctx.String("wg-name"))
 				if err != nil {
 					re, ok := err.(*cleura.RequestAPIError)
 					if ok {

--- a/cmd/cleura/shootcmd/genkubecfg.go
+++ b/cmd/cleura/shootcmd/genkubecfg.go
@@ -45,6 +45,7 @@ func genKubeConfigCommand() *cli.Command {
 				"api-host",
 				"region",
 				"project-id",
+				"gardener-domain",
 			)
 			if err != nil {
 				return err

--- a/cmd/cleura/shootcmd/genkubecfg.go
+++ b/cmd/cleura/shootcmd/genkubecfg.go
@@ -58,6 +58,7 @@ func genKubeConfigCommand() *cli.Command {
 				return err
 			}
 			body, err := client.GenerateKubeConfig(
+				ctx.String("gardener-domain"),
 				ctx.String("region"),
 				ctx.String("project-id"),
 				ctx.String("cluster-name"),

--- a/cmd/cleura/shootcmd/hibernatecmd.go
+++ b/cmd/cleura/shootcmd/hibernatecmd.go
@@ -44,7 +44,7 @@ func hibernateCommand() *cli.Command {
 			if err != nil {
 				return err
 			}
-			err = client.HibernateCluster(ctx.String("region"), ctx.String("project-id"), ctx.String("cluster-name"))
+			err = client.HibernateCluster(ctx.String("gardener-domain"), ctx.String("region"), ctx.String("project-id"), ctx.String("cluster-name"))
 			if err != nil {
 				return err
 			}

--- a/cmd/cleura/shootcmd/hibernatecmd.go
+++ b/cmd/cleura/shootcmd/hibernatecmd.go
@@ -32,6 +32,7 @@ func hibernateCommand() *cli.Command {
 				"api-host",
 				"region",
 				"project-id",
+				"gardener-domain",
 			)
 			if err != nil {
 				return err

--- a/cmd/cleura/shootcmd/listcmd.go
+++ b/cmd/cleura/shootcmd/listcmd.go
@@ -45,7 +45,7 @@ func listCommand() *cli.Command {
 			if err != nil {
 				return err
 			}
-			clusterList, err := client.ListShootClusters(ctx.String("region"), ctx.String("project-id"))
+			clusterList, err := client.ListShootClusters(ctx.String("gardener-domain"), ctx.String("region"), ctx.String("project-id"))
 			if err != nil {
 				re, ok := err.(*cleura.RequestAPIError)
 				if ok {

--- a/cmd/cleura/shootcmd/listcmd.go
+++ b/cmd/cleura/shootcmd/listcmd.go
@@ -33,6 +33,7 @@ func listCommand() *cli.Command {
 				"api-host",
 				"region",
 				"project-id",
+				"gardener-domain",
 			)
 			if err != nil {
 				return err

--- a/cmd/cleura/shootcmd/wakeupcmd.go
+++ b/cmd/cleura/shootcmd/wakeupcmd.go
@@ -44,7 +44,7 @@ func wakeupCommand() *cli.Command {
 			if err != nil {
 				return err
 			}
-			err = client.WakeUpCluster(ctx.String("region"), ctx.String("project-id"), ctx.String("cluster-name"))
+			err = client.WakeUpCluster(ctx.String("gardener-domain"), ctx.String("region"), ctx.String("project-id"), ctx.String("cluster-name"))
 			if err != nil {
 				return err
 			}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aztekas/cleura-client-go
 
-go 1.21.5
+go 1.24.3
 
 require (
 	github.com/gofrs/flock v0.8.1

--- a/pkg/api/cleura/shootclusters.go
+++ b/pkg/api/cleura/shootclusters.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 )
 
-func (c *Client) GetShootCluster(clusterName string, clusterRegion string, clusterProject string) (*ShootClusterResponse, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/gardener/v1/public/shoot/%s/%s/%s", c.HostURL, clusterRegion, clusterProject, clusterName), nil)
+func (c *Client) GetShootCluster(gardenDomain string, clusterName string, clusterRegion string, clusterProject string) (*ShootClusterResponse, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/gardener/v1/%s/shoot/%s/%s/%s", c.HostURL, gardenDomain, clusterRegion, clusterProject, clusterName), nil)
 	//https://rest.cleura.cloud/gardener/v1/:gardenDomain/shoot/:region/:project/:shootName
 	if err != nil {
 		return nil, err
@@ -26,8 +26,8 @@ func (c *Client) GetShootCluster(clusterName string, clusterRegion string, clust
 	return &shoot, nil
 }
 
-func (c *Client) ListShootClusters(clusterRegion string, clusterProject string) ([]ShootClusterResponse, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/gardener/v1/public/shoot/%s/%s", c.HostURL, clusterRegion, clusterProject), nil)
+func (c *Client) ListShootClusters(gardenDomain string, clusterRegion string, clusterProject string) ([]ShootClusterResponse, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/gardener/v1/%s/shoot/%s/%s", c.HostURL, gardenDomain, clusterRegion, clusterProject), nil)
 	//https://rest.cleura.cloud/gardener/v1/:gardenDomain/shoot/:region/:project
 	if err != nil {
 		return nil, err
@@ -45,13 +45,13 @@ func (c *Client) ListShootClusters(clusterRegion string, clusterProject string) 
 	return shoots, nil
 }
 
-func (c *Client) CreateShootCluster(clusterRegion string, clusterProject string, shootClusterRequest ShootClusterRequest) (*ShootClusterCreateResponse, error) {
+func (c *Client) CreateShootCluster(gardenDomain string, clusterRegion string, clusterProject string, shootClusterRequest ShootClusterRequest) (*ShootClusterCreateResponse, error) {
 	//https://rest.cleura.cloud/gardener/v1/:gardenDomain/shoot/:region/:project
 	crJsonByte, err := json.Marshal(shootClusterRequest)
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/gardener/v1/public/shoot/%s/%s", c.HostURL, clusterRegion, clusterProject), strings.NewReader(string(crJsonByte)))
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/gardener/v1/%s/shoot/%s/%s", c.HostURL, gardenDomain, clusterRegion, clusterProject), strings.NewReader(string(crJsonByte)))
 	if err != nil {
 		return nil, err
 	}
@@ -68,9 +68,9 @@ func (c *Client) CreateShootCluster(clusterRegion string, clusterProject string,
 	return &createdShootCluster, nil
 }
 
-func (c *Client) DeleteShootCluster(clusterName string, clusterRegion string, clusterProject string) (string, error) {
+func (c *Client) DeleteShootCluster(gardenDomain string, clusterName string, clusterRegion string, clusterProject string) (string, error) {
 	//https://rest.cleura.cloud/gardener/v1/:gardenDomain/shoot/:region/:project/:shoot
-	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/gardener/v1/public/shoot/%s/%s/%s", c.HostURL, clusterRegion, clusterProject, clusterName), nil)
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/gardener/v1/%s/shoot/%s/%s/%s", c.HostURL, gardenDomain, clusterRegion, clusterProject, clusterName), nil)
 	if err != nil {
 		return "", err
 	}
@@ -81,13 +81,13 @@ func (c *Client) DeleteShootCluster(clusterName string, clusterRegion string, cl
 	return string(body), nil
 }
 
-func (c *Client) UpdateShootCluster(clusterRegion string, clusterProject string, clusterName string, shootClusterUpdateRequest ShootClusterRequest) (*ShootClusterResponse, error) {
+func (c *Client) UpdateShootCluster(gardenDomain string, clusterRegion string, clusterProject string, clusterName string, shootClusterUpdateRequest ShootClusterRequest) (*ShootClusterResponse, error) {
 	crJsonByte, err := json.Marshal(shootClusterUpdateRequest)
 	if err != nil {
 		return nil, err
 	}
 	//https://rest.cleura.cloud/gardener/v1/:gardenDomain/shoot/:region/:project/:shoot
-	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/gardener/v1/public/shoot/%s/%s/%s", c.HostURL, clusterRegion, clusterProject, clusterName), strings.NewReader(string(crJsonByte)))
+	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/gardener/v1/%s/shoot/%s/%s/%s", c.HostURL, gardenDomain, clusterRegion, clusterProject, clusterName), strings.NewReader(string(crJsonByte)))
 	if err != nil {
 		return nil, err
 	}
@@ -104,13 +104,13 @@ func (c *Client) UpdateShootCluster(clusterRegion string, clusterProject string,
 	return &createdShootCluster, nil
 }
 
-func (c *Client) AddWorkerGroup(clusterName string, clusterRegion string, clusterProject string, workerGroupRequest WorkerGroupRequest) (*ShootClusterResponse, error) {
+func (c *Client) AddWorkerGroup(gardenDomain string, clusterName string, clusterRegion string, clusterProject string, workerGroupRequest WorkerGroupRequest) (*ShootClusterResponse, error) {
 	//https://rest.cleura.cloud/gardener/v1/:gardenDomain/shoot/:region/:project/:shoot/worker
 	wgrJsonByte, err := json.Marshal(workerGroupRequest)
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/gardener/v1/public/shoot/%s/%s/%s/worker", c.HostURL, clusterRegion, clusterProject, clusterName), strings.NewReader(string(wgrJsonByte)))
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/gardener/v1/%s/shoot/%s/%s/%s/worker", c.HostURL, gardenDomain, clusterRegion, clusterProject, clusterName), strings.NewReader(string(wgrJsonByte)))
 	if err != nil {
 		return nil, err
 	}
@@ -127,13 +127,13 @@ func (c *Client) AddWorkerGroup(clusterName string, clusterRegion string, cluste
 	return &updatedShootCluster, nil
 }
 
-func (c *Client) UpdateWorkerGroup(clusterName string, clusterRegion string, clusterProject string, workerName string, workerGroupRequest WorkerGroupRequest) (*ShootClusterResponse, error) {
+func (c *Client) UpdateWorkerGroup(gardenDomain string, clusterName string, clusterRegion string, clusterProject string, workerName string, workerGroupRequest WorkerGroupRequest) (*ShootClusterResponse, error) {
 	// https://rest.cleura.cloud/gardener/v1/:gardenDomain/shoot/:region/:project/:shoot/worker/:workerName
 	wgrJsonByte, err := json.Marshal(workerGroupRequest)
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/gardener/v1/public/shoot/%s/%s/%s/worker/%s", c.HostURL, clusterRegion, clusterProject, clusterName, workerName), strings.NewReader(string(wgrJsonByte)))
+	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/gardener/v1/%s/shoot/%s/%s/%s/worker/%s", c.HostURL, gardenDomain, clusterRegion, clusterProject, clusterName, workerName), strings.NewReader(string(wgrJsonByte)))
 	if err != nil {
 		return nil, err
 	}
@@ -150,10 +150,10 @@ func (c *Client) UpdateWorkerGroup(clusterName string, clusterRegion string, clu
 	return &updatedShootCluster, nil
 }
 
-func (c *Client) DeleteWorkerGroup(clusterName string, clusterRegion string, clusterProject string, workerName string) (*ShootClusterResponse, error) {
+func (c *Client) DeleteWorkerGroup(gardenDomain string, clusterName string, clusterRegion string, clusterProject string, workerName string) (*ShootClusterResponse, error) {
 	//https://rest.cleura.cloud/gardener/v1/:gardenDomain/shoot/:region/:project/:shoot/worker/:worker
 
-	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/gardener/v1/public/shoot/%s/%s/%s/worker/%s", c.HostURL, clusterRegion, clusterProject, clusterName, workerName), nil)
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/gardener/v1/%s/shoot/%s/%s/%s/worker/%s", c.HostURL, gardenDomain, clusterRegion, clusterProject, clusterName, workerName), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (c *Client) DeleteWorkerGroup(clusterName string, clusterRegion string, clu
 	return &updatedShootCluster, nil
 }
 
-func (c *Client) GenerateKubeConfig(clusterRegion string, clusterProject string, clusterName string, durationSeconds int64) ([]byte, error) {
+func (c *Client) GenerateKubeConfig(gardenDomain, clusterRegion string, clusterProject string, clusterName string, durationSeconds int64) ([]byte, error) {
 	//https://rest.cleura.cloud/gardener/v1/public/shoot/kna1/b5d2bf2c162444f4918aaa4cb534a612/myshoot/adminkubeconfig
 
 	type Config struct {
@@ -187,7 +187,7 @@ func (c *Client) GenerateKubeConfig(clusterRegion string, clusterProject string,
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/gardener/v1/public/shoot/%s/%s/%s/adminkubeconfig", c.HostURL, clusterRegion, clusterProject, clusterName), strings.NewReader(string(requestJsonByte)))
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/gardener/v1/%s/shoot/%s/%s/%s/adminkubeconfig", c.HostURL, gardenDomain, clusterRegion, clusterProject, clusterName), strings.NewReader(string(requestJsonByte)))
 	if err != nil {
 		return nil, err
 	}
@@ -199,9 +199,9 @@ func (c *Client) GenerateKubeConfig(clusterRegion string, clusterProject string,
 }
 
 // Hibernate.
-func (c *Client) HibernateCluster(clusterRegion string, clusterProject string, clusterName string) error {
+func (c *Client) HibernateCluster(gardenDomain string, clusterRegion string, clusterProject string, clusterName string) error {
 	// https://rest.cleura.cloud/gardener/v1/:gardenDomain/shoot/:region/:project/:shoot/hibernate
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/gardener/v1/public/shoot/%s/%s/%s/hibernate", c.HostURL, clusterRegion, clusterProject, clusterName), nil)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/gardener/v1/%s/shoot/%s/%s/%s/hibernate", c.HostURL, gardenDomain, clusterRegion, clusterProject, clusterName), nil)
 	if err != nil {
 		return err
 	}
@@ -213,9 +213,9 @@ func (c *Client) HibernateCluster(clusterRegion string, clusterProject string, c
 }
 
 // Wake up call.
-func (c *Client) WakeUpCluster(clusterRegion string, clusterProject string, clusterName string) error {
+func (c *Client) WakeUpCluster(gardenDomain string, clusterRegion string, clusterProject string, clusterName string) error {
 	// https://rest.cleura.cloud/gardener/v1/:gardenDomain/shoot/:region/:project/:shoot/wakeup
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/gardener/v1/public/shoot/%s/%s/%s/wakeup", c.HostURL, clusterRegion, clusterProject, clusterName), nil)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/gardener/v1/%s/shoot/%s/%s/%s/wakeup", c.HostURL, gardenDomain, clusterRegion, clusterProject, clusterName), nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/configfile/configfile.go
+++ b/pkg/configfile/configfile.go
@@ -30,6 +30,7 @@ type profile struct {
 	DefaultRegion    string `yaml:"region,omitempty"`
 	DefaultProjectID string `yaml:"project-id,omitempty"`
 	ApiUrl           string `yaml:"api-url,omitempty"`
+	GardenerDomain   string `yaml:"gardener-domain,omitempty"`
 }
 
 // Validate configuration file for active profile and profile data.
@@ -52,7 +53,7 @@ func (c *Configuration) GetActiveProfile() string {
 }
 
 // Add new profile to the configuration file.
-func (c *Configuration) AddProfile(name string, username string, token string, domainid string, region string, projectid string, apiurl string) error {
+func (c *Configuration) AddProfile(name string, username string, token string, domainid string, region string, projectid string, apiurl string, gardenDomain string) error {
 	c.configFile.Profiles[name] = profile{
 		Username:         username,
 		Token:            token,
@@ -60,6 +61,7 @@ func (c *Configuration) AddProfile(name string, username string, token string, d
 		DefaultRegion:    region,
 		DefaultProjectID: projectid,
 		ApiUrl:           apiurl,
+		GardenerDomain:   gardenDomain,
 	}
 	err := writeConfigFile(c.Location, c.configFile)
 	if err != nil {
@@ -171,6 +173,7 @@ func CreateConfigTemplateFile(filename string) error {
 				DefaultRegion:    "region-placeholder",
 				DefaultProjectID: "projectid-placeholder",
 				ApiUrl:           "https://rest.cleura.cloud",
+				GardenerDomain:   "public",
 			},
 		},
 	}


### PR DESCRIPTION
Adds a new argument for gardener domain, as 'public' is reffering to Cleura's public cloud, and compliant uses a different path.

Also bumps the go version to 1.24.3