### PR TITLE
feat: Add support for monitoring creds

### DIFF
--- a/cmd/cleura/shootcmd/getkubeconfig.go
+++ b/cmd/cleura/shootcmd/getkubeconfig.go
@@ -1,0 +1,88 @@
+package shootcmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/aztekas/cleura-client-go/cmd/cleura/common"
+	"github.com/aztekas/cleura-client-go/cmd/cleura/configcmd"
+	"github.com/aztekas/cleura-client-go/pkg/api/cleura"
+	"github.com/aztekas/cleura-client-go/pkg/configfile"
+	"github.com/urfave/cli/v2"
+)
+
+func getKubeConfigCommand() *cli.Command {
+	commonFlags := append(common.CleuraAuthFlags(), common.LocationFlags()...)
+	return &cli.Command{
+		Name:        "get-kubeconfig",
+		Description: "Get kubeconfig for selected shoot cluster",
+		Usage:       "Get  kubeconfig for selected shoot cluster. NB: overwrites existing kubeconfig",
+		Before:      configcmd.TrySetConfigFromFile,
+		Flags: append(
+			commonFlags,
+			&cli.StringFlag{
+				Name:    "output-path",
+				Aliases: []string{"o"},
+				Usage:   "Specify path with filename to store kubeconfig. Print to stdout if not set",
+			},
+			&cli.StringFlag{
+				Name:     "cluster-name",
+				Required: true,
+				Aliases:  []string{"n"},
+				Usage:    "Shoot cluster name",
+			},
+		),
+		Action: func(ctx *cli.Context) error {
+			err := common.ValidateNotEmptyString(ctx,
+				"token",
+				"username",
+				"api-host",
+				"region",
+				"project-id",
+				"gardener-domain",
+			)
+			if err != nil {
+				return err
+			}
+			token := ctx.String("token")
+			username := ctx.String("username")
+			host := ctx.String("api-host")
+
+			client, err := cleura.NewClientNoPassword(&host, &username, &token)
+			if err != nil {
+				return err
+			}
+			body, err := client.GetKubeConfig(
+				ctx.String("gardener-domain"),
+				ctx.String("region"),
+				ctx.String("project-id"),
+				ctx.String("cluster-name"),
+			)
+			if err != nil {
+				re, ok := err.(*cleura.RequestAPIError)
+				if ok {
+					if re.StatusCode == 403 {
+						return fmt.Errorf("error: invalid token")
+					}
+				}
+				return err
+			}
+			var configContent interface{}
+			err = json.Unmarshal(body, &configContent)
+			if err != nil {
+				return err
+			}
+			content, ok := configContent.(string)
+			if !ok {
+				return fmt.Errorf("error: cannot assert string")
+			}
+			if ctx.String("output-path") != "" {
+				err := configfile.WriteByteToFile(ctx.String("output-path"), []byte(content))
+				return err
+			} else {
+				fmt.Println(content)
+			}
+			return nil
+		},
+	}
+}

--- a/cmd/cleura/shootcmd/monitoringcreds.go
+++ b/cmd/cleura/shootcmd/monitoringcreds.go
@@ -1,0 +1,90 @@
+package shootcmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/aztekas/cleura-client-go/cmd/cleura/common"
+	"github.com/aztekas/cleura-client-go/cmd/cleura/configcmd"
+	"github.com/aztekas/cleura-client-go/pkg/api/cleura"
+	"github.com/aztekas/cleura-client-go/pkg/configfile"
+	"github.com/urfave/cli/v2"
+)
+
+func getMonitoringCredentialsCommand() *cli.Command {
+	commonFlags := append(common.CleuraAuthFlags(), common.LocationFlags()...)
+	return &cli.Command{
+		Name:        "get-monitoring-creds",
+		Description: "Get monitoring credentials for selected shoot cluster",
+		Usage:       "Get monitoring credentials for selected shoot cluster. NB: overwrites existing output file",
+		Before:      configcmd.TrySetConfigFromFile,
+		Flags: append(
+			commonFlags,
+			&cli.StringFlag{
+				Name:    "output-path",
+				Aliases: []string{"o"},
+				Usage:   "Specify path with filename to store kubeconfig. Print to stdout if not set",
+			},
+			&cli.StringFlag{
+				Name:     "cluster-name",
+				Required: true,
+				Aliases:  []string{"n"},
+				Usage:    "Shoot cluster name",
+			},
+		),
+		Action: func(ctx *cli.Context) error {
+			err := common.ValidateNotEmptyString(ctx,
+				"token",
+				"username",
+				"api-host",
+				"region",
+				"project-id",
+				"gardener-domain",
+			)
+			if err != nil {
+				return err
+			}
+			token := ctx.String("token")
+			username := ctx.String("username")
+			host := ctx.String("api-host")
+
+			client, err := cleura.NewClientNoPassword(&host, &username, &token)
+			if err != nil {
+				return err
+			}
+			body, err := client.GetMonitoringCredentials(
+				ctx.String("gardener-domain"),
+				ctx.String("region"),
+				ctx.String("project-id"),
+				ctx.String("cluster-name"),
+			)
+			if err != nil {
+				re, ok := err.(*cleura.RequestAPIError)
+				if ok {
+					if re.StatusCode == 403 {
+						return fmt.Errorf("error: invalid token")
+					}
+				}
+				return err
+			}
+			var content interface{}
+			err = json.Unmarshal(body, &content)
+			if err != nil {
+				return err
+			}
+
+			prettyJson, err := json.MarshalIndent(content, "", "  ")
+			if err != nil {
+				return err
+			}
+
+			if ctx.String("output-path") != "" {
+				err := configfile.WriteByteToFile(ctx.String("output-path"), prettyJson)
+				return err
+			} else {
+				fmt.Println(string(prettyJson))
+			}
+			return nil
+		},
+	}
+}

--- a/cmd/cleura/shootcmd/shoot.go
+++ b/cmd/cleura/shootcmd/shoot.go
@@ -9,6 +9,8 @@ func Command() *cli.Command {
 		Usage:       "Command used to perform operations with shoot clusters",
 		Subcommands: []*cli.Command{
 			genKubeConfigCommand(),
+			getKubeConfigCommand(),
+			getMonitoringCredentialsCommand(),
 			listCommand(),
 			createCommand(),
 			deleteCommand(),

--- a/pkg/api/cleura/models.go
+++ b/pkg/api/cleura/models.go
@@ -19,6 +19,7 @@ type ShootClusterCreateConfigResponse struct {
 	Purpose     string                        `json:"purpose"`
 	Region      string                        `json:"region"`
 	Hibernation HibernationDetails            `json:"hibernation"`
+	Maintenance MaintenanceDetails            `json:"maintenance,omitempty"`
 }
 
 type MetadataFieldsResponse struct {
@@ -43,6 +44,21 @@ type HibernationResponseSchedule struct {
 	Start    string `json:"start"`
 	End      string `json:"end"`
 	Location string `json:"location"`
+}
+
+type MaintenanceDetails struct {
+	AutoUpdate AutoUpdateDetails `json:"autoUpdate,omitempty"`
+	TimeWindow TimeWindowDetails `json:"timeWindow,omitempty"`
+}
+
+type AutoUpdateDetails struct {
+	KubernetesVersion   bool `json:"kubernetesVersion"`
+	MachineImageVersion bool `json:"machineImageVersion"`
+}
+
+type TimeWindowDetails struct {
+	Begin string `json:"begin"`
+	End   string `json:"end"`
 }
 
 type KubernetesDetailsResponse struct {
@@ -83,6 +99,7 @@ type ShootClusterRequestConfig struct {
 	KubernetesVersion *K8sVersion             `json:"kubernetes,omitempty"`
 	Provider          *ProviderDetailsRequest `json:"provider,omitempty"`
 	Hibernation       *HibernationSchedules   `json:"hibernation,omitempty"`
+	Maintenance       *MaintenanceDetails     `json:"maintenance,omitempty"`
 }
 type K8sVersion struct {
 	Version string `json:"version"`

--- a/pkg/api/cleura/shootclusters.go
+++ b/pkg/api/cleura/shootclusters.go
@@ -198,6 +198,34 @@ func (c *Client) GenerateKubeConfig(gardenDomain, clusterRegion string, clusterP
 	return body, nil
 }
 
+func (c *Client) GetKubeConfig(gardenDomain, clusterRegion string, clusterProject string, clusterName string) ([]byte, error) {
+	// https://rest.cleura.cloud/gardener/v1/:gardenDomain/shoot/:region/:project/:shootName/Kubeconfig
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/gardener/v1/%s/shoot/%s/%s/%s/kubeconfig", c.HostURL, gardenDomain, clusterRegion, clusterProject, clusterName), nil)
+	if err != nil {
+		return nil, err
+	}
+	body, err := c.doRequest(req, 200)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func (c *Client) GetMonitoringCredentials(gardenDomain, clusterRegion string, clusterProject string, clusterName string) ([]byte, error) {
+	// https://rest.cleura.cloud/gardener/v1/:gardenDomain/shoot/:region/:project/:shootName/Kubeconfig
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/gardener/v1/%s/shoot/%s/%s/%s/monitoring", c.HostURL, gardenDomain, clusterRegion, clusterProject, clusterName), nil)
+	if err != nil {
+		return nil, err
+	}
+	body, err := c.doRequest(req, 200)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
 // Hibernate.
 func (c *Client) HibernateCluster(gardenDomain string, clusterRegion string, clusterProject string, clusterName string) error {
 	// https://rest.cleura.cloud/gardener/v1/:gardenDomain/shoot/:region/:project/:shoot/hibernate

--- a/test.py
+++ b/test.py
@@ -1,8 +1,0 @@
-
-def main():
-    with open('TODO.md', 'rb') as f:
-        data = f.read()
-        print(len(data))
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
Adds cli functions to retrieve kubeconfig and credentials for the monitoring services running in the Gardener cluster. It will print it as JSON to stdout by default, with the possibility to specify an output file with `-o <path to file>`.

```sh
$ cleura shoot get-monitoring-creds --cluster-name my-cluster --gardener-domain public --region sto2  --project-id <project id>
{
  "plutono": {
    "password": "<PASSWORD>",
    "url": "https://<plutono service name>.garden.k8s.cleura.cloud",
    "username": "<USERNAME>"
  },
  "prometheus": {
    "password": "<PASSWORD>",
    "url": "https://<prometheus service name>.garden.k8s.cleura.cloud",
    "username": "<USERNAME>"
  }
}
```

