### PR TITLE
fix: update data models for maintenance block

### DIFF
--- a/cmd/cleura/shootcmd/createcmd.go
+++ b/cmd/cleura/shootcmd/createcmd.go
@@ -271,11 +271,11 @@ func generateShootClusterRequest(ctx *cli.Context) cleura.ShootClusterRequest {
 				Version: ctx.String("k8s-version"),
 			},
 			Maintenance: &cleura.MaintenanceDetails{
-				AutoUpdate: cleura.AutoUpdateDetails{
+				AutoUpdate: &cleura.AutoUpdateDetails{
 					KubernetesVersion:   ctx.Bool("allow-k8s-autoupdate"),
 					MachineImageVersion: ctx.Bool("allow-worker-image-autoupdate"),
 				},
-				TimeWindow: cleura.TimeWindowDetails{
+				TimeWindow: &cleura.TimeWindowDetails{
 					Begin: "000000+0000",
 					End:   "010000+0000",
 				},
@@ -313,7 +313,7 @@ func generateShootClusterRequest(ctx *cli.Context) cleura.ShootClusterRequest {
 	}
 
 	if ctx.String("maintenance-start") != "" && ctx.String("maintenance-end") != "" {
-		clusterReq.Shoot.Maintenance.TimeWindow = cleura.TimeWindowDetails{
+		clusterReq.Shoot.Maintenance.TimeWindow = &cleura.TimeWindowDetails{
 			Begin: ctx.String("maintenance-start"),
 			End:   ctx.String("maintenance-end"),
 		}

--- a/pkg/api/cleura/models.go
+++ b/pkg/api/cleura/models.go
@@ -19,7 +19,7 @@ type ShootClusterCreateConfigResponse struct {
 	Purpose     string                        `json:"purpose"`
 	Region      string                        `json:"region"`
 	Hibernation HibernationDetails            `json:"hibernation"`
-	Maintenance MaintenanceDetails            `json:"maintenance,omitempty"`
+	Maintenance MaintenanceDetails            `json:"maintenance"`
 }
 
 type MetadataFieldsResponse struct {
@@ -33,6 +33,7 @@ type SpecFieldsResponse struct {
 	Provider    ProviderDetailsUpdateResponse `json:"provider"`
 	Kubernetes  KubernetesDetailsResponse     `json:"kubernetes"`
 	Hibernation HibernationDetails            `json:"hibernation"`
+	Maintenance MaintenanceDetails            `json:"maintenance"`
 }
 
 type HibernationDetails struct {
@@ -47,8 +48,8 @@ type HibernationResponseSchedule struct {
 }
 
 type MaintenanceDetails struct {
-	AutoUpdate AutoUpdateDetails `json:"autoUpdate,omitempty"`
-	TimeWindow TimeWindowDetails `json:"timeWindow,omitempty"`
+	AutoUpdate *AutoUpdateDetails `json:"autoUpdate,omitempty"`
+	TimeWindow *TimeWindowDetails `json:"timeWindow,omitempty"`
 }
 
 type AutoUpdateDetails struct {


### PR DESCRIPTION
Fixes manitenance model to use a pointer to the maintenance struct, so it can be omitted