### PR TITLE
feat: support using a pre-provisioned network

### DIFF
--- a/pkg/api/cleura/models.go
+++ b/pkg/api/cleura/models.go
@@ -122,15 +122,19 @@ type ProviderDetailsUpdateResponse struct {
 }
 
 type InfrastructureConfigDetails struct {
-	FloatingPoolName string `json:"floatingPoolName"`
-	// Networks *WorkerNetwork `json:"networks,omitempty"`
+	FloatingPoolName string         `json:"floatingPoolName"`
+	Networks         *WorkerNetwork `json:"networks,omitempty"`
 }
 
-/*
 type WorkerNetwork struct {
+	Id          string `json:"id,omitempty"`
+	Router      Router `json:"router,omitempty"`
 	WorkersCIDR string `json:"workers,omitempty"`
 }
-*/
+
+type Router struct {
+	Id string `json:"id,omitempty"`
+}
 
 // Worker.
 type WorkerRequest struct {


### PR DESCRIPTION
Allows the user to select a pre-provisioned network for the worker nodes by supplying the `--network-id`  and `--router-id` flags. It also supports configuring a custom CIDR range too with the `--subnet-cidr` flag.